### PR TITLE
fix: make docker frontends host-aware

### DIFF
--- a/SYNC_STATUS.md
+++ b/SYNC_STATUS.md
@@ -1,5 +1,5 @@
 # Sync Status
 
-- Repository synchronized with upstream `origin/main` at commit `e98e399`.
-- Upstream commit message: "publisher onboarding v1".
-- Fetch performed on 2025-09-29 02:49:43 UTC.
+- Repository synchronized with upstream `origin/main` at commit `9a7e3418f177b805019dcc2ff6d5702a620730f6`.
+- Upstream commit message: "Merge pull request #2 from woedy/codex/update-codex-environment-with-zamio-updates-4ioig9".
+- Fetch performed on 2025-09-29 06:35:44 UTC.

--- a/zamio_backend/README.md
+++ b/zamio_backend/README.md
@@ -74,6 +74,11 @@ docker-compose -f docker-compose.local.yml up -d
 # Django: http://localhost:9001
 # PostgreSQL: localhost:9003
 # Redis: localhost:9004
+
+> **Heads up:** The React/Vite frontends read `VITE_API_URL` at build time to know where to call the Django API. The Docker
+> Compose file now defaults this to `http://localhost:9001` so local browsers keep working. When you run the stack on a remote
+> host, export a public URL before booting (for example `export VITE_API_URL=http://31.97.156.207:9001 && docker-compose -f
+> docker-compose.local.yml up -d`).
 ```
 
 ### **Django Commands**

--- a/zamio_backend/docker-compose.local.yml
+++ b/zamio_backend/docker-compose.local.yml
@@ -50,7 +50,7 @@ services:
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       # Local development settings
       ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0,host.docker.internal,db,redis,zamio_app,31.97.156.207"
-      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002"
+      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002,http://31.97.156.207:9002,http://31.97.156.207:9005,http://31.97.156.207:9006,http://31.97.156.207:9007"
       BASE_URL: "http://localhost:9001"
     volumes:
       - .:/zamio_django
@@ -80,7 +80,7 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0,host.docker.internal,db,redis,zamio_app,31.97.156.207"
-      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002"
+      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002,http://31.97.156.207:9002,http://31.97.156.207:9005,http://31.97.156.207:9006,http://31.97.156.207:9007"
       BASE_URL: "http://localhost:9001"
     volumes:
       - .:/zamio_django
@@ -106,7 +106,7 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0,host.docker.internal,db,redis,zamio_app,31.97.156.207"
-      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002"
+      CSRF_TRUSTED_ORIGINS: "http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002,http://31.97.156.207:9002,http://31.97.156.207:9005,http://31.97.156.207:9006,http://31.97.156.207:9007"
       BASE_URL: "http://localhost:9001"
     volumes:
       - .:/zamio_django
@@ -131,7 +131,7 @@ services:
       - /zamio_frontend_pro/node_modules
     environment:
       - CHOKIDAR_USEPOLLING=true
-      - VITE_API_URL=http://host.docker.internal:9001
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:9001}
     depends_on:
       - zamio_app
     networks:
@@ -150,7 +150,7 @@ services:
       - /zamio_stations_pro/node_modules
     environment:
       - CHOKIDAR_USEPOLLING=true
-      - VITE_API_URL=http://host.docker.internal:9001
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:9001}
     depends_on:
       - zamio_app
     networks:
@@ -168,7 +168,7 @@ services:
       - /zamio_publishers_pro/node_modules
     environment:
       - CHOKIDAR_USEPOLLING=true
-      - VITE_API_URL=http://host.docker.internal:9001
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:9001}
     depends_on:
       - zamio_app
     networks:
@@ -186,7 +186,7 @@ services:
       - /zamio_admin_pro/node_modules
     environment:
       - CHOKIDAR_USEPOLLING=true
-      - VITE_API_URL=http://host.docker.internal:9001
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:9001}
     depends_on:
       - zamio_app
     networks:

--- a/zamio_backend/env.local.example
+++ b/zamio_backend/env.local.example
@@ -21,7 +21,7 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Local Development Settings
 ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0,db,redis,zamio_app,31.97.156.207
-CSRF_TRUSTED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001
+CSRF_TRUSTED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001,http://31.97.156.207:9001,http://localhost:9002,http://127.0.0.1:9002,http://31.97.156.207:9002,http://31.97.156.207:9005,http://31.97.156.207:9006,http://31.97.156.207:9007
 # For non-DEBUG scenarios, list allowed origins (comma-separated) for CORS
 # CORS_ALLOWED_ORIGINS=http://localhost:9002,http://127.0.0.1:9002
 SECURE_SSL_REDIRECT=false


### PR DESCRIPTION
## Summary
- point all dockerised frontends at the host-exposed API by default while still permitting overrides via `VITE_API_URL` for remote deployments
- broaden trusted CSRF origins to cover the published frontend ports used on the remote host
- mirror the new trusted origin guidance in the sample local environment file
- document the `VITE_API_URL` override workflow in the backend README so remote hosts know how to publish the API

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da275ad1c48326aa68e80b1ed35ce8