### PR TITLE
Fix station verification and onboarding refresh flows

### DIFF
--- a/zamio_stations/src/hooks/useStationOnboarding.ts
+++ b/zamio_stations/src/hooks/useStationOnboarding.ts
@@ -1,78 +1,14 @@
-import { useCallback, useEffect, useState } from 'react';
-import api from '../lib/api';
-
-export interface OnboardingStatus {
-  is_onboarded: boolean;
-  onboarding_step: string;
-  next_recommended_step: string;
-  station_id: string;
-  station_name: string;
-  // Add other fields as per your API response
-}
-
-// Mock data for development
-const mockOnboardingStatus: OnboardingStatus = {
-  is_onboarded: true,
-  onboarding_step: 'done',
-  next_recommended_step: 'done',
-  station_id: 'mock-station-123',
-  station_name: 'Mock Station',
-};
+import { useStationOnboardingContext } from '../contexts/StationOnboardingContext';
 
 const useStationOnboarding = () => {
-  const [status, setStatus] = useState<OnboardingStatus | undefined>(
-    import.meta.env.DEV ? mockOnboardingStatus : undefined,
-  );
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<unknown>(null);
-
-  const fetchStatus = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      if (import.meta.env.DEV) {
-        console.log('Using mock onboarding status data');
-        setStatus(mockOnboardingStatus);
-        return mockOnboardingStatus;
-      }
-
-      const response = await api.get('/api/v1/station/onboarding/status');
-      setStatus(response.data);
-      return response.data;
-    } catch (err: any) {
-      console.error('Error fetching onboarding status:', {
-        message: err?.message,
-        response: err?.response?.data,
-        status: err?.response?.status,
-        url: err?.config?.url,
-      });
-
-      if (import.meta.env.DEV) {
-        console.warn('API request failed, using mock data as fallback');
-        setStatus(mockOnboardingStatus);
-        return mockOnboardingStatus;
-      }
-
-      setStatus(undefined);
-      setError(err);
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchStatus().catch(() => {
-      // error state handled in fetchStatus
-    });
-  }, [fetchStatus]);
+  const { status, details, loading, error, refresh } = useStationOnboardingContext();
 
   return {
     status,
+    details,
     loading,
     error,
-    refetch: fetchStatus,
+    refresh,
   };
 };
 

--- a/zamio_stations/src/pages/Authentication/Onboarding/AddStaff.tsx
+++ b/zamio_stations/src/pages/Authentication/Onboarding/AddStaff.tsx
@@ -49,7 +49,7 @@ const AddStaff = () => {
       if (!nextStep || nextStep === 'staff') {
         nextStep = 'payment';
       }
-      await refresh();
+      await refresh({ silent: true });
 
       switch (nextStep) {
         case 'profile':
@@ -171,7 +171,7 @@ const AddStaff = () => {
                     station_id: getStationId(),
                     step: 'payment',
                   });
-                  await refresh();
+                  await refresh({ silent: true });
                 } catch {}
                 navigate(getOnboardingRoute('payment'));
               }}

--- a/zamio_stations/src/pages/Authentication/Onboarding/CompleteProfile.tsx
+++ b/zamio_stations/src/pages/Authentication/Onboarding/CompleteProfile.tsx
@@ -10,8 +10,8 @@ const CompleteProfile = () => {
   const [bio, setBio] = useState('');
   const [country, setCountry] = useState('');
   const [region, setRegion] = useState('');
-  const [imagePreview, setImagePreview] = useState(null);
-  const [selectedFile, setSelectedFile] = useState(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   const [inputError, setInputError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -24,8 +24,10 @@ const CompleteProfile = () => {
       setBio(details.bio ?? '');
       setCountry(details.country ?? '');
       setRegion(details.region ?? '');
-      if (details.photo) {
-        setImagePreview(details.photo as unknown as string);
+      if (typeof details.photo === 'string' && details.photo) {
+        setImagePreview(details.photo);
+      } else {
+        setImagePreview(null);
       }
     }
   }, [details]);
@@ -35,7 +37,7 @@ const CompleteProfile = () => {
     if (file && file.type.startsWith('image/')) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setImagePreview(reader.result);
+        setImagePreview(typeof reader.result === 'string' ? reader.result : null);
       };
       reader.readAsDataURL(file);
       setSelectedFile(file); // <-- store actual file here
@@ -91,7 +93,7 @@ const CompleteProfile = () => {
       if (!nextStep || nextStep === 'profile') {
         nextStep = 'staff';
       }
-      await refresh();
+      await refresh({ silent: true });
 
       switch (nextStep) {
         case 'profile':
@@ -228,7 +230,7 @@ const CompleteProfile = () => {
                     station_id: getStationId(),
                     step: 'staff',
                   });
-                  await refresh();
+                  await refresh({ silent: true });
                 } catch {}
                 navigate(getOnboardingRoute('staff'));
               }}

--- a/zamio_stations/src/pages/Authentication/Onboarding/PaymentInfo.tsx
+++ b/zamio_stations/src/pages/Authentication/Onboarding/PaymentInfo.tsx
@@ -47,7 +47,7 @@ const PaymentInfo = () => {
       if (!nextStep || nextStep === 'payment') {
         nextStep = 'done';
       }
-      await refresh();
+      await refresh({ silent: true });
 
       switch (nextStep) {
         case 'profile':
@@ -80,7 +80,7 @@ const PaymentInfo = () => {
       await api.post('api/accounts/complete-station-onboarding/', {
         station_id: getStationId(),
       });
-      await refresh();
+      await refresh({ silent: true });
     } catch {}
     navigate(getOnboardingRoute('done'));
   };

--- a/zamio_stations/src/pages/Authentication/SignIn.tsx
+++ b/zamio_stations/src/pages/Authentication/SignIn.tsx
@@ -64,7 +64,7 @@ const SignIn = () => {
       const response = await api.post(url, data);
       if (response.status === 200) {
         const user = response.data.data;
-  
+
         // Save to localStorage
         localStorage.setItem('first_name', user.first_name);
         localStorage.setItem('last_name', user.last_name);
@@ -73,8 +73,13 @@ const SignIn = () => {
         localStorage.setItem('email', user.email);
         localStorage.setItem('photo', user.photo);
         localStorage.setItem('token', user.token);
-  
-        await refresh();
+        try {
+          sessionStorage.setItem('token', user.token);
+        } catch {
+          /* ignore storage errors */
+        }
+
+        await refresh({ silent: true });
         const targetRoute = getOnboardingRoute(user.onboarding_step);
         navigate(targetRoute);
       }


### PR DESCRIPTION
## Summary
- replace the station onboarding hook with the shared context implementation so the UI always reflects backend state
- harden station email verification and login flows, persisting tokens and handling resend/refresh logic with better feedback
- refresh onboarding steps silently after profile, staff, and payment actions and tighten file handling for profile uploads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db6f0b642083268a30c1a5d4c59224